### PR TITLE
double http in soap url bugfix

### DIFF
--- a/lib/Transip/Client.php
+++ b/lib/Transip/Client.php
@@ -67,7 +67,7 @@ class Client
      * @param string $endpoint
      * @param bool   $proxy
      */
-    public function __construct($login, $privateKey, $debug = false, $endpoint = 'https://api.transip.nl', $proxy = false)
+    public function __construct($login, $privateKey, $debug = false, $endpoint = 'api.transip.nl', $proxy = false)
     {
         $this->login      = $login;
         $this->privateKey = $privateKey;


### PR DESCRIPTION
The `https://` is already added in `SoapClientAbstract`:

```
$wsdlUri = 'https://' . $endpoint . '/wsdl/?service=' . $this->service;
```

so the endpoint param shouldn't have it.